### PR TITLE
Use Roboto or fall back to sans-serif

### DIFF
--- a/src/client/styles/layout.scss
+++ b/src/client/styles/layout.scss
@@ -21,7 +21,7 @@
    padding: 0;
    margin: 0;
    height: 100%;
-   font-family: Roboto;
+   font-family: 'Roboto', sans-serif;
  }
 
  main {

--- a/src/client/styles/style.scss
+++ b/src/client/styles/style.scss
@@ -17,11 +17,12 @@
  *
  */
 
-@font-face {
+ @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto'), local('Roboto-Regular'), url(https://fonts.gstatic.com/s/roboto/v18/Ks_cVxiCiwUWVsFWFA3Bjn-_kf6ByYO6CLYdB4HQE-Y.woff2) format('woff2');
+  src: local('Roboto'), local('Roboto-Regular'), url(https://fonts.gstatic.com/s/roboto/v18/CWB0XYA8bzo0kSThX0UTuA.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215;
 }
 
 $mobile-break: 470px;


### PR DESCRIPTION
Previous URL was pointing to a font that wasn't Roboto, which was confusing.