### PR TITLE
Add support for multiple entry points.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,7 @@ script:
   - npm run test
 before_script:
   - "export DISPLAY=:99.0"
+  - "sudo chown root /opt/google/chrome/chrome-sandbox"
+  - "sudo chmod 4755 /opt/google/chrome/chrome-sandbox"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start

--- a/src/client/js/category-main.js
+++ b/src/client/js/category-main.js
@@ -17,17 +17,7 @@
  *
  */
 
-import {Router} from 'express';
-const router = new Router();
+import init from './category.js';
+import router from './router.js';
 
-/* GET home page. */
-router.get('/', (req, res, next) => {
-  res.render('index', {
-    title: 'Pie Shop',
-    scripts: [
-      'js/index-bundle.js',
-    ],
-  });
-});
-
-export default router;
+init();

--- a/src/client/js/category-main.js
+++ b/src/client/js/category-main.js
@@ -18,6 +18,6 @@
  */
 
 import init from './category.js';
-import router from './router.js';
+// import router from './router.js';
 
 init();

--- a/src/client/js/category.js
+++ b/src/client/js/category.js
@@ -17,17 +17,6 @@
  *
  */
 
-import {Router} from 'express';
-const router = new Router();
-
-/* GET home page. */
-router.get('/', (req, res, next) => {
-  res.render('index', {
-    title: 'Pie Shop',
-    scripts: [
-      'js/index-bundle.js',
-    ],
-  });
-});
-
-export default router;
+export default function init() {
+  console.log('Category init.');
+}

--- a/src/client/js/index-main.js
+++ b/src/client/js/index-main.js
@@ -18,6 +18,6 @@
  */
 
 import init from './index.js';
-import router from './router.js';
+// import router from './router.js';
 
 init();

--- a/src/client/js/index-main.js
+++ b/src/client/js/index-main.js
@@ -17,17 +17,7 @@
  *
  */
 
-import {Router} from 'express';
-const router = new Router();
+import init from './index.js';
+import router from './router.js';
 
-/* GET home page. */
-router.get('/', (req, res, next) => {
-  res.render('index', {
-    title: 'Pie Shop',
-    scripts: [
-      'js/index-bundle.js',
-    ],
-  });
-});
-
-export default router;
+init();

--- a/src/client/js/index.js
+++ b/src/client/js/index.js
@@ -17,13 +17,6 @@
  *
  */
 
-import initializeFirebase from './firebase.js';
-import initializeProducts from './listing.js';
-import PieImg from './pie-img.js';
-import PieItem from './pie-item.js';
-
-initializeFirebase();
-window.customElements.define('pie-img', PieImg);
-window.customElements.define('pie-item', PieItem);
-
-initializeProducts();
+export default function init() {
+  console.log('Index init.');
+}

--- a/src/client/js/listing-main.js
+++ b/src/client/js/listing-main.js
@@ -18,4 +18,6 @@
  */
 
 import init from './listing.js';
+import router from './router.js';
+
 init();

--- a/src/client/js/listing-main.js
+++ b/src/client/js/listing-main.js
@@ -18,6 +18,6 @@
  */
 
 import init from './listing.js';
-import router from './router.js';
+// import router from './router.js';
 
 init();

--- a/src/client/js/listing.js
+++ b/src/client/js/listing.js
@@ -42,6 +42,7 @@ function initializeProducts() {
 }
 
 export default function init() {
+  console.log('Listing init.');
   initializeFirebase();
   initializeProducts();
 }

--- a/src/client/js/product-main.js
+++ b/src/client/js/product-main.js
@@ -18,6 +18,6 @@
  */
 
 import init from './product.js';
-import router from './router.js';
+// import router from './router.js';
 
 init();

--- a/src/client/js/product-main.js
+++ b/src/client/js/product-main.js
@@ -17,17 +17,7 @@
  *
  */
 
-import {Router} from 'express';
-const router = new Router();
+import init from './product.js';
+import router from './router.js';
 
-/* GET home page. */
-router.get('/', (req, res, next) => {
-  res.render('index', {
-    title: 'Pie Shop',
-    scripts: [
-      'js/index-bundle.js',
-    ],
-  });
-});
-
-export default router;
+init();

--- a/src/client/js/product.js
+++ b/src/client/js/product.js
@@ -17,17 +17,6 @@
  *
  */
 
-import {Router} from 'express';
-const router = new Router();
-
-/* GET home page. */
-router.get('/', (req, res, next) => {
-  res.render('index', {
-    title: 'Pie Shop',
-    scripts: [
-      'js/index-bundle.js',
-    ],
-  });
-});
-
-export default router;
+export default function init() {
+  console.log('Product init.');
+}

--- a/src/client/js/router.js
+++ b/src/client/js/router.js
@@ -1,0 +1,13 @@
+const _modules = {
+  category: () => import('./category.js'),
+  index: () => import('./index.js'),
+  listing: () => import('./listing.js'),
+  product: () => import('./product.js'),
+  search: () => import('./search.js'),
+};
+
+export default class Router {
+  static get modules() {
+    return _modules;
+  }
+}

--- a/src/client/js/search-main.js
+++ b/src/client/js/search-main.js
@@ -18,6 +18,6 @@
  */
 
 import init from './search.js';
-import router from './router.js';
+// import router from './router.js';
 
 init();

--- a/src/client/js/search-main.js
+++ b/src/client/js/search-main.js
@@ -17,17 +17,7 @@
  *
  */
 
-import {Router} from 'express';
-const router = new Router();
+import init from './search.js';
+import router from './router.js';
 
-/* GET home page. */
-router.get('/', (req, res, next) => {
-  res.render('index', {
-    title: 'Pie Shop',
-    scripts: [
-      'js/index-bundle.js',
-    ],
-  });
-});
-
-export default router;
+init();

--- a/src/client/js/search.js
+++ b/src/client/js/search.js
@@ -17,17 +17,6 @@
  *
  */
 
-import {Router} from 'express';
-const router = new Router();
-
-/* GET home page. */
-router.get('/', (req, res, next) => {
-  res.render('index', {
-    title: 'Pie Shop',
-    scripts: [
-      'js/index-bundle.js',
-    ],
-  });
-});
-
-export default router;
+export default function init() {
+  console.log('Search init.');
+}

--- a/src/server/js/routes/category.js
+++ b/src/server/js/routes/category.js
@@ -25,7 +25,11 @@ router.get('/', (req, res, next) => {
   res.render('category', {
     title: 'Sweet Pies — Pie Shop',
     category_name: 'Sweet Pies',
-    category_description: 'Great for a special dessert or an indulgent afternoon tea.'});
+    category_description: 'Great for a special dessert or an indulgent afternoon tea.',
+    scripts: [
+      'js/category-bundle.js',
+    ],
+  });
 });
 
 export default router;

--- a/src/server/js/routes/listing.js
+++ b/src/server/js/routes/listing.js
@@ -22,8 +22,8 @@ const router = new Router();
 
 /* GET home page. */
 router.get('/', (req, res, next) => {
-  import('../services/firebase').then((fbAdmin) => {
-    fbAdmin.database().ref('/products').once('value').then((snapshot) => {
+  import('../services/firebase.js').then((fbService) => {
+    fbService.default.database().ref('/products').once('value').then((snapshot) => {
       res.render('listing', {
         title: 'Holiday Pies — Pie Shop',
         listing_name: 'Holiday Pies',
@@ -31,7 +31,7 @@ router.get('/', (req, res, next) => {
         products: snapshot.val(),
         scripts: [
           'https://www.gstatic.com/firebasejs/4.6.2/firebase.js',
-          'js/listing_main.js',
+          'js/listing-bundle.js',
         ],
       });
     });

--- a/src/server/js/routes/product.js
+++ b/src/server/js/routes/product.js
@@ -25,7 +25,11 @@ router.get('/', (req, res, next) => {
   res.render('product', {
     title: 'Apple Pie — Pie Shop',
     product_name: 'Apple Pie',
-    product_description: 'A classic dessert, with our unique exotic spice blend.'});
+    product_description: 'A classic dessert, with our unique exotic spice blend.',
+    scripts: [
+      'js/product-bundle.js',
+    ],
+  });
 });
 
 export default router;

--- a/src/server/js/routes/search.js
+++ b/src/server/js/routes/search.js
@@ -24,6 +24,9 @@ const router = new Router();
 router.get('/', (req, res, next) => {
   res.render('search', {
     title: 'Search — Pie Shop',
+    scripts: [
+      'js/search-bundle.js',
+    ],
   });
 });
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -9,8 +9,11 @@ const BROWSERS = [
 
 module.exports = {
   entry: {
-    main: './src/client/js/app.js',
-    listing_main: './src/client/js/listing-main.js',
+    'index-bundle': './src/client/js/index-main.js',
+    'listing-bundle': './src/client/js/listing-main.js',
+    'product-bundle': './src/client/js/product-main.js',
+    'search-bundle': './src/client/js/search-main.js',
+    'category-bundle': './src/client/js/category-main.js',
   },
   module: {
     rules: [


### PR DESCRIPTION
This PR standardises all routes to have a `<name>.js` and a `<name>-main.js`, where the latter serves as an entry point for the former. Each route generates a bundle of the form `<name>-bundle.js`, which gets loaded for that particular route.

Once we have client-side routing, it can be placed in `router.js`, which has access to the modules for all routes via lazy-loading.

This PR implements the pattern detailed in https://sgom.es/posts/2018-01-18-multiple-routes-webpack/