### PR TITLE
Slim appengine deploy

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,4 +1,7 @@
+# Use a whitelist approach here as by default we want to ignore *everything*
 *
+
+# and only upload these three targets
 !/dist/**
 !/app.yaml
 !/package.json

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,4 @@
+*
+!/dist/**
+!/app.yaml
+!/package.json


### PR DESCRIPTION
Whitelist **only** the files needed for the production environment to run on AppEngine.