### PR TITLE
Simplify Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ dist: trusty
 language: node_js
 node_js:
   - 'lts/*'
-install:
-  - npm i -g npm@6.1.0
-  - npm ci
+git:
+  depth: false
+cache:
+  directories:
+    - node_modules
+before_install:
+  - npm i -g npm@latest
 script:
   - npm run lint
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ dist: trusty
 language: node_js
 node_js:
   - 'lts/*'
-git:
-  depth: 5
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - 'lts/*'
 git:
-  depth: false
+  depth: 5
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
- Shallow Git checkout
- Cache node modules
- Move `npm` update to `before_install` step
- `npm ci` should run by default if supported