### PR TITLE
Skip cleanup so that the `dist` dir can be deployed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
   - npm run build
 deploy:
   provider: gae
+  skip_cleanup: true
   keyfile: ".travis-deploy-key.json"
   project: "pie-shop-app"
   default: true


### PR DESCRIPTION
By default, Travis removes the build artifacts after it completes. This means the `dist` directory gets deleted, which is kind of important to retain if we want to deploy it anywhere.