### PR TITLE
Deploy the production version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - npm i -g npm@latest
 script:
   - npm run lint
-  - npm run build
+  - npm run build:prod
 deploy:
   provider: gae
   skip_cleanup: true


### PR DESCRIPTION
Travis should deploy the production build, not the development build. When the test suite is fixed, a previous build step may run the development build again but at the moment it's not required.