### PR TITLE
Linking to compiled js file instead of raw one

### DIFF
--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -27,7 +27,7 @@ const search = {
       layout: req.query.fragment ? 'fragment' : 'layout',
       query: req.params.query,
       scripts: [
-        '/js/search-main.js',
+        '/js/search_main.js',
       ],
       title: 'PWA Shop: Search',
     });


### PR DESCRIPTION
It is important to link to bundled version of the file rather than raw, so that all dependencies are included. You can see the bundling config in https://github.com/GoogleChromeLabs/sample-pie-shop/blob/master/webpack.common.js